### PR TITLE
Reworked CI build workflows a.o. 

### DIFF
--- a/.ci/vcpkg-configuration.json
+++ b/.ci/vcpkg-configuration.json
@@ -7,11 +7,11 @@
         }
     ],
     "requires": {
-        "arm:tools/open-cmsis-pack/cmsis-toolbox": "^2.6.0",
-        "arm:tools/arm/mdk-toolbox":" ^1.0.0",
-        "arm:tools/kitware/cmake": "^3.28.4",
-        "arm:tools/ninja-build/ninja": "^1.12.0",
-        "arm:compilers/arm/armclang": "^6.22.0",
-        "arm:compilers/arm/arm-none-eabi-gcc": "^13.3.1"
+        "arm:tools/open-cmsis-pack/cmsis-toolbox": "^2.9.0",
+        "arm:tools/arm/mdk-toolbox":" ^1.1.0",
+        "arm:tools/kitware/cmake": "^3.31.5",
+        "arm:tools/ninja-build/ninja": "^1.12.1",
+        "arm:compilers/arm/armclang": "^6.24.0",
+        "arm:compilers/arm/arm-none-eabi-gcc": "^14.2.1"
     }
 }

--- a/.github/workflows/Test-Examples.yml
+++ b/.github/workflows/Test-Examples.yml
@@ -62,13 +62,13 @@ jobs:
         working-directory: ./
         run: |
           mkdir -p ./CI/Examples/Blinky
-          cp -rf ./BSP/Examples/Blinky/* ./CI/Examples/Blinky/
+          cp -a ./BSP/Examples/Blinky/. ./CI/Examples/Blinky/
 
       - name: Build Blinky AC6
         if: always()
         working-directory: ./CI/Examples/Blinky
         run: |
-          cbuild ./Blinky.csolution.yml --packs --update-rte --packs --toolchain AC6 --rebuild
+          cbuild ./Blinky.csolution.yml --packs --toolchain AC6 --rebuild
 
       - name: Upload Artifact of the Blinky AC6 build
         if: always()

--- a/.github/workflows/Test-MDK-Middleware-RefApps.yml
+++ b/.github/workflows/Test-MDK-Middleware-RefApps.yml
@@ -84,7 +84,7 @@ jobs:
         run: |
           if [ -e ./.ci/MW-RefApps/Examples/${{ matrix.solution.dir }}/${{ matrix.solution.name }}.csolution.yml ]
           then
-             cp -rf ./.ci/MW-RefApps/Examples/${{ matrix.solution.dir }}/${{ matrix.solution.name }}.csolution.yml ./CI/MW-RefApps/Examples/${{ matrix.solution.dir }}/${{ matrix.solution.name }}.csolution.yml
+             cp -f ./.ci/MW-RefApps/Examples/${{ matrix.solution.dir }}/${{ matrix.solution.name }}.csolution.yml ./CI/MW-RefApps/Examples/${{ matrix.solution.dir }}/${{ matrix.solution.name }}.csolution.yml
           fi
 
       - name: Add the board layer to the ${{ matrix.solution.dir }}/${{ matrix.solution.name }}.csolution.yml

--- a/.github/workflows/Test-MDK-Middleware-RefApps.yml
+++ b/.github/workflows/Test-MDK-Middleware-RefApps.yml
@@ -19,10 +19,8 @@ jobs:
       fail-fast: false
       matrix:
         solution: [
-#         {name: FileSystem, dir: FileSystem, layer_ac6: ./BSP/Layers/Default, layer_gcc: ./.ci/Layers/Default_GCC},
           {name: Network,    dir: Network,    layer_ac6: ./BSP/Layers/Default, layer_gcc: ./.ci/Layers/Default_GCC},
-          {name: USB_Device, dir: USB/Device, layer_ac6: ./BSP/Layers/Default, layer_gcc: ./.ci/Layers/Default_GCC},
-#         {name: USB_Host,   dir: USB/Host,   layer_ac6: ./BSP/Layers/Default, layer_gcc: ./.ci/Layers/Default_GCC}
+          {name: USB_Device, dir: USB/Device, layer_ac6: ./BSP/Layers/Default, layer_gcc: ./.ci/Layers/Default_GCC}
         ]
 
     steps:
@@ -78,15 +76,20 @@ jobs:
       - name: Copy example structure to CI/MW-RefApps/ folder
         working-directory: ./
         run: |
-          mkdir -p ./CI/MW-RefApps/Examples/
           mkdir -p ./CI/MW-RefApps/Examples/${{ matrix.solution.dir }}/Board/
-          cp -rf ./MDK-Middleware/Examples/* ./CI/MW-RefApps/Examples/
+          cp -a ./MDK-Middleware/Examples/${{ matrix.solution.dir }}/. ./CI/MW-RefApps/Examples/${{ matrix.solution.dir }}/
 
+      - name: Replace specific csolution files
+        working-directory: ./
+        run: |
           if [ -e ./.ci/MW-RefApps/Examples/${{ matrix.solution.dir }}/${{ matrix.solution.name }}.csolution.yml ]
           then
              cp -rf ./.ci/MW-RefApps/Examples/${{ matrix.solution.dir }}/${{ matrix.solution.name }}.csolution.yml ./CI/MW-RefApps/Examples/${{ matrix.solution.dir }}/${{ matrix.solution.name }}.csolution.yml
           fi
 
+      - name: Add the board layer to the ${{ matrix.solution.dir }}/${{ matrix.solution.name }}.csolution.yml
+        working-directory: ./
+        run: |
           sed -i "s|target-types:|&\n    - type: $TARGET_BOARD\n      board: $TARGET_BOARD\n      variables:\n        - Board-Layer: \$SolutionDir()\$/Board/Board.clayer.yml|"  ./CI/MW-RefApps/Examples/${{ matrix.solution.dir }}/${{ matrix.solution.name }}.csolution.yml
 
       - name: Update board layer for ${{ matrix.solution.name }} AC6 build test

--- a/Examples/Blinky/.cmsis/Blinky+NUCLEO-H563ZI.dbgconf
+++ b/Examples/Blinky/.cmsis/Blinky+NUCLEO-H563ZI.dbgconf
@@ -1,0 +1,128 @@
+// File: STM32H562xx_H563xx_H573xx.dbgconf
+// Version: 1.0.1
+// Note: refer to STM32H563/H573 and STM32H562 reference manual (RM0481)
+//       refer to STM32H562xx STM32H563xx STM32H573xx datasheets
+
+// <<< Use Configuration Wizard in Context Menu >>>
+
+// <h> Debug MCU configuration register (DBGMCU_CR)
+//   <o.2>  DBG_STANDBY              <i> Debug standby mode
+//   <o.1>  DBG_STOP                 <i> Debug stop mode
+// </h>
+DbgMCU_CR = 0x00000006;
+
+// <h> Debug MCU APB1L freeze register (DBGMCU_APB1LFZR)
+//                                   <i> Reserved bits must be kept at reset value
+//   <o.23> DBG_I2C3_STOP            <i> I2C3 SMBUS timeout is frozen while CPU is in debug mode
+//   <o.22> DBG_I2C2_STOP            <i> I2C2 SMBUS timeout is frozen while CPU is in debug mode
+//   <o.21> DBG_I2C1_STOP            <i> I2C1 SMBUS timeout is frozen while CPU is in debug mode
+//   <o.12> DBG_IWDG_STOP            <i> Debug independent watchdog is frozen while CPU is in debug mode
+//   <o.11> DBG_WWDG_STOP            <i> Debug window watchdog is frozen while CPU is in debug mode
+//   <o.8>  DBG_TIM14_STOP           <i> TIM14 is frozen while CPU is in debug mode
+//   <o.7>  DBG_TIM13_STOP           <i> TIM13 is frozen while CPU is in debug mode
+//   <o.6>  DBG_TIM12_STOP           <i> TIM12 is frozen while CPU is in debug mode
+//   <o.5>  DBG_TIM7_STOP            <i> TIM7 is frozen while CPU is in debug mode
+//   <o.4>  DBG_TIM6_STOP            <i> TIM6 is frozen while CPU is in debug mode
+//   <o.3>  DBG_TIM5_STOP            <i> TIM5 is frozen while CPU is in debug mode
+//   <o.2>  DBG_TIM4_STOP            <i> TIM4 is frozen while CPU is in debug mode
+//   <o.1>  DBG_TIM3_STOP            <i> TIM3 is frozen while CPU is in debug mode
+//   <o.0>  DBG_TIM2_STOP            <i> TIM2 is frozen while CPU is in debug mode
+// </h>
+DbgMCU_APB1L_Fz = 0x00000000;
+
+// <h> Debug MCU APB1H freeze register (DBGMCU_APB1HFZR)
+//                                   <i> Reserved bits must be kept at reset value
+//   <o.5>  DBG_LPTIM2_STOP          <i> LPTIM2 is frozen while CPU is in debug mode
+// </h>
+DbgMCU_APB1H_Fz = 0x00000000;
+
+// <h> Debug MCU APB2 freeze register (DBGMCU_APB2FZR)
+//                                   <i> Reserved bits must be kept at reset value
+//   <o.18> DBG_TIM17_STOP           <i> TIM17 is frozen while CPU is in debug mode
+//   <o.17> DBG_TIM16_STOP           <i> TIM16 is frozen while CPU is in debug mode
+//   <o.16> DBG_TIM15_STOP           <i> TIM15 is frozen while CPU is in debug mode
+//   <o.13> DBG_TIM8_STOP            <i> TIM8 is frozen while CPU is in debug mode
+//   <o.11> DBG_TIM1_STOP            <i> TIM1 is frozen while CPU is in debug mode
+// </h>
+DbgMCU_APB2_Fz = 0x00000000;
+
+// <h> Debug MCU APB3 freeze register (DBGMCU_APB3FZR)
+//                                   <i> Reserved bits must be kept at reset value
+//   <o.30> DBG_RTC_STOP             <i> RTC is frozen while CPU is in debug mode.
+//   <o.21> DBG_LPTIM6_STOP          <i> LPTIM6 is frozen while CPU is in debug mode
+//   <o.20> DBG_LPTIM5_STOP          <i> LPTIM5 is frozen while CPU is in debug mode
+//   <o.19> DBG_LPTIM4_STOP          <i> LPTIM4 is frozen while CPU is in debug mode
+//   <o.18> DBG_LPTIM3_STOP          <i> LPTIM3 is frozen while CPU is in debug mode
+//   <o.17> DBG_LPTIM1_STOP          <i> LPTIM1 is frozen while CPU is in debug mode
+//   <o.11> DBG_I2C4_STOP            <i> I2C3 is frozen while CPU is in debug mode
+//   <o.10> DBG_I2C3_STOP            <i> I2C3 is frozen while CPU is in debug mode
+// </h>
+DbgMCU_APB3_Fz = 0x00000000;
+
+// <h> Debug MCU AHB1 freeze register (DBGMCU_AHB1FZR)
+//                                   <i> Reserved bits must be kept at reset value
+//   <o.31> DBG_GPDMA2_15_STOP       <i> GPDMA2 channel 15 is frozen while CPU is in debug mode
+//   <o.30> DBG_GPDMA2_14_STOP       <i> GPDMA2 channel 14 is frozen while CPU is in debug mode
+//   <o.29> DBG_GPDMA2_13_STOP       <i> GPDMA2 channel 13 is frozen while CPU is in debug mode
+//   <o.28> DBG_GPDMA2_12_STOP       <i> GPDMA2 channel 12 is frozen while CPU is in debug mode
+//   <o.27> DBG_GPDMA2_11_STOP       <i> GPDMA2 channel 11 is frozen while CPU is in debug mode
+//   <o.26> DBG_GPDMA2_10_STOP       <i> GPDMA2 channel 10 is frozen while CPU is in debug mode
+//   <o.25> DBG_GPDMA2_9_STOP        <i> GPDMA2 channel 9 is frozen while CPU is in debug mode
+//   <o.24> DBG_GPDMA2_8_STOP        <i> GPDMA2 channel 8 is frozen while CPU is in debug mode
+//   <o.23> DBG_GPDMA2_7_STOP        <i> GPDMA2 channel 7 is frozen while CPU is in debug mode
+//   <o.22> DBG_GPDMA2_6_STOP        <i> GPDMA2 channel 6 is frozen while CPU is in debug mode
+//   <o.21> DBG_GPDMA2_5_STOP        <i> GPDMA2 channel 5 is frozen while CPU is in debug mode
+//   <o.20> DBG_GPDMA2_4_STOP        <i> GPDMA2 channel 4 is frozen while CPU is in debug mode
+//   <o.19> DBG_GPDMA2_3_STOP        <i> GPDMA2 channel 3 is frozen while CPU is in debug mode
+//   <o.18> DBG_GPDMA2_2_STOP        <i> GPDMA2 channel 2 is frozen while CPU is in debug mode
+//   <o.17> DBG_GPDMA2_1_STOP        <i> GPDMA2 channel 1 is frozen while CPU is in debug mode
+//   <o.16> DBG_GPDMA2_0_STOP        <i> GPDMA2 channel 0 is frozen while CPU is in debug mode
+//   <o.15> DBG_GPDMA1_15_STOP       <i> GPDMA1 channel 15 is frozen while CPU is in debug mode
+//   <o.14> DBG_GPDMA1_14_STOP       <i> GPDMA1 channel 14 is frozen while CPU is in debug mode
+//   <o.13> DBG_GPDMA1_13_STOP       <i> GPDMA1 channel 13 is frozen while CPU is in debug mode
+//   <o.12> DBG_GPDMA1_12_STOP       <i> GPDMA1 channel 12 is frozen while CPU is in debug mode
+//   <o.11> DBG_GPDMA1_11_STOP       <i> GPDMA1 channel 11 is frozen while CPU is in debug mode
+//   <o.10> DBG_GPDMA1_10_STOP       <i> GPDMA1 channel 10 is frozen while CPU is in debug mode
+//   <o.9>  DBG_GPDMA1_9_STOP        <i> GPDMA1 channel 9 is frozen while CPU is in debug mode
+//   <o.8>  DBG_GPDMA1_8_STOP        <i> GPDMA1 channel 8 is frozen while CPU is in debug mode
+//   <o.7>  DBG_GPDMA1_7_STOP        <i> GPDMA1 channel 7 is frozen while CPU is in debug mode
+//   <o.6>  DBG_GPDMA1_6_STOP        <i> GPDMA1 channel 6 is frozen while CPU is in debug mode
+//   <o.5>  DBG_GPDMA1_5_STOP        <i> GPDMA1 channel 5 is frozen while CPU is in debug mode
+//   <o.4>  DBG_GPDMA1_4_STOP        <i> GPDMA1 channel 4 is frozen while CPU is in debug mode
+//   <o.3>  DBG_GPDMA1_3_STOP        <i> GPDMA1 channel 3 is frozen while CPU is in debug mode
+//   <o.2>  DBG_GPDMA1_2_STOP        <i> GPDMA1 channel 2 is frozen while CPU is in debug mode
+//   <o.1>  DBG_GPDMA1_1_STOP        <i> GPDMA1 channel 1 is frozen while CPU is in debug mode
+//   <o.0>  DBG_GPDMA1_0_STOP        <i> GPDMA1 channel 0 is frozen while CPU is in debug mode
+// </h>
+DbgMCU_AHB1_Fz = 0x00000000;
+
+// <h> TPIU Pin Routing
+//   <o0> TRACECLK
+//     <i> ETM Trace Clock
+//       <0x00040002=> Pin PE2
+//   <o1> TRACED0
+//     <i> ETM Trace Data 0
+//       <0x0006000D=> Pin PG13
+//       <0x00040003=> Pin PE3
+//       <0x00020001=> Pin PC1
+//   <o2> TRACED1
+//     <i> ETM Trace Data 1
+//       <0x0006000E=> Pin PG14
+//       <0x00040004=> Pin PE4
+//       <0x00020008=> Pin PC8
+//   <o3> TRACED2
+//     <i> ETM Trace Data 2
+//       <0x00040005=> Pin PE5
+//       <0x00030002=> Pin PD2
+//   <o4> TRACED3
+//     <i> ETM Trace Data 3
+//       <0x0002000C=> Pin PC12
+//       <0x00040006=> Pin PE6
+// </h>
+TraceClk_Pin = 0x00040002;
+TraceD0_Pin  = 0x00040003;
+TraceD1_Pin  = 0x00040004;
+TraceD2_Pin  = 0x00040005;
+TraceD3_Pin  = 0x00040006;
+
+// <<< end of configuration section >>>

--- a/Examples/Blinky/.cmsis/Blinky+NUCLEO-H563ZI.dbgconf.base@1.0.0
+++ b/Examples/Blinky/.cmsis/Blinky+NUCLEO-H563ZI.dbgconf.base@1.0.0
@@ -1,0 +1,128 @@
+// File: STM32H562xx_H563xx_H573xx.dbgconf
+// Version: 1.0.1
+// Note: refer to STM32H563/H573 and STM32H562 reference manual (RM0481)
+//       refer to STM32H562xx STM32H563xx STM32H573xx datasheets
+
+// <<< Use Configuration Wizard in Context Menu >>>
+
+// <h> Debug MCU configuration register (DBGMCU_CR)
+//   <o.2>  DBG_STANDBY              <i> Debug standby mode
+//   <o.1>  DBG_STOP                 <i> Debug stop mode
+// </h>
+DbgMCU_CR = 0x00000006;
+
+// <h> Debug MCU APB1L freeze register (DBGMCU_APB1LFZR)
+//                                   <i> Reserved bits must be kept at reset value
+//   <o.23> DBG_I2C3_STOP            <i> I2C3 SMBUS timeout is frozen while CPU is in debug mode
+//   <o.22> DBG_I2C2_STOP            <i> I2C2 SMBUS timeout is frozen while CPU is in debug mode
+//   <o.21> DBG_I2C1_STOP            <i> I2C1 SMBUS timeout is frozen while CPU is in debug mode
+//   <o.12> DBG_IWDG_STOP            <i> Debug independent watchdog is frozen while CPU is in debug mode
+//   <o.11> DBG_WWDG_STOP            <i> Debug window watchdog is frozen while CPU is in debug mode
+//   <o.8>  DBG_TIM14_STOP           <i> TIM14 is frozen while CPU is in debug mode
+//   <o.7>  DBG_TIM13_STOP           <i> TIM13 is frozen while CPU is in debug mode
+//   <o.6>  DBG_TIM12_STOP           <i> TIM12 is frozen while CPU is in debug mode
+//   <o.5>  DBG_TIM7_STOP            <i> TIM7 is frozen while CPU is in debug mode
+//   <o.4>  DBG_TIM6_STOP            <i> TIM6 is frozen while CPU is in debug mode
+//   <o.3>  DBG_TIM5_STOP            <i> TIM5 is frozen while CPU is in debug mode
+//   <o.2>  DBG_TIM4_STOP            <i> TIM4 is frozen while CPU is in debug mode
+//   <o.1>  DBG_TIM3_STOP            <i> TIM3 is frozen while CPU is in debug mode
+//   <o.0>  DBG_TIM2_STOP            <i> TIM2 is frozen while CPU is in debug mode
+// </h>
+DbgMCU_APB1L_Fz = 0x00000000;
+
+// <h> Debug MCU APB1H freeze register (DBGMCU_APB1HFZR)
+//                                   <i> Reserved bits must be kept at reset value
+//   <o.5>  DBG_LPTIM2_STOP          <i> LPTIM2 is frozen while CPU is in debug mode
+// </h>
+DbgMCU_APB1H_Fz = 0x00000000;
+
+// <h> Debug MCU APB2 freeze register (DBGMCU_APB2FZR)
+//                                   <i> Reserved bits must be kept at reset value
+//   <o.18> DBG_TIM17_STOP           <i> TIM17 is frozen while CPU is in debug mode
+//   <o.17> DBG_TIM16_STOP           <i> TIM16 is frozen while CPU is in debug mode
+//   <o.16> DBG_TIM15_STOP           <i> TIM15 is frozen while CPU is in debug mode
+//   <o.13> DBG_TIM8_STOP            <i> TIM8 is frozen while CPU is in debug mode
+//   <o.11> DBG_TIM1_STOP            <i> TIM1 is frozen while CPU is in debug mode
+// </h>
+DbgMCU_APB2_Fz = 0x00000000;
+
+// <h> Debug MCU APB3 freeze register (DBGMCU_APB3FZR)
+//                                   <i> Reserved bits must be kept at reset value
+//   <o.30> DBG_RTC_STOP             <i> RTC is frozen while CPU is in debug mode.
+//   <o.21> DBG_LPTIM6_STOP          <i> LPTIM6 is frozen while CPU is in debug mode
+//   <o.20> DBG_LPTIM5_STOP          <i> LPTIM5 is frozen while CPU is in debug mode
+//   <o.19> DBG_LPTIM4_STOP          <i> LPTIM4 is frozen while CPU is in debug mode
+//   <o.18> DBG_LPTIM3_STOP          <i> LPTIM3 is frozen while CPU is in debug mode
+//   <o.17> DBG_LPTIM1_STOP          <i> LPTIM1 is frozen while CPU is in debug mode
+//   <o.11> DBG_I2C4_STOP            <i> I2C3 is frozen while CPU is in debug mode
+//   <o.10> DBG_I2C3_STOP            <i> I2C3 is frozen while CPU is in debug mode
+// </h>
+DbgMCU_APB3_Fz = 0x00000000;
+
+// <h> Debug MCU AHB1 freeze register (DBGMCU_AHB1FZR)
+//                                   <i> Reserved bits must be kept at reset value
+//   <o.31> DBG_GPDMA2_15_STOP       <i> GPDMA2 channel 15 is frozen while CPU is in debug mode
+//   <o.30> DBG_GPDMA2_14_STOP       <i> GPDMA2 channel 14 is frozen while CPU is in debug mode
+//   <o.29> DBG_GPDMA2_13_STOP       <i> GPDMA2 channel 13 is frozen while CPU is in debug mode
+//   <o.28> DBG_GPDMA2_12_STOP       <i> GPDMA2 channel 12 is frozen while CPU is in debug mode
+//   <o.27> DBG_GPDMA2_11_STOP       <i> GPDMA2 channel 11 is frozen while CPU is in debug mode
+//   <o.26> DBG_GPDMA2_10_STOP       <i> GPDMA2 channel 10 is frozen while CPU is in debug mode
+//   <o.25> DBG_GPDMA2_9_STOP        <i> GPDMA2 channel 9 is frozen while CPU is in debug mode
+//   <o.24> DBG_GPDMA2_8_STOP        <i> GPDMA2 channel 8 is frozen while CPU is in debug mode
+//   <o.23> DBG_GPDMA2_7_STOP        <i> GPDMA2 channel 7 is frozen while CPU is in debug mode
+//   <o.22> DBG_GPDMA2_6_STOP        <i> GPDMA2 channel 6 is frozen while CPU is in debug mode
+//   <o.21> DBG_GPDMA2_5_STOP        <i> GPDMA2 channel 5 is frozen while CPU is in debug mode
+//   <o.20> DBG_GPDMA2_4_STOP        <i> GPDMA2 channel 4 is frozen while CPU is in debug mode
+//   <o.19> DBG_GPDMA2_3_STOP        <i> GPDMA2 channel 3 is frozen while CPU is in debug mode
+//   <o.18> DBG_GPDMA2_2_STOP        <i> GPDMA2 channel 2 is frozen while CPU is in debug mode
+//   <o.17> DBG_GPDMA2_1_STOP        <i> GPDMA2 channel 1 is frozen while CPU is in debug mode
+//   <o.16> DBG_GPDMA2_0_STOP        <i> GPDMA2 channel 0 is frozen while CPU is in debug mode
+//   <o.15> DBG_GPDMA1_15_STOP       <i> GPDMA1 channel 15 is frozen while CPU is in debug mode
+//   <o.14> DBG_GPDMA1_14_STOP       <i> GPDMA1 channel 14 is frozen while CPU is in debug mode
+//   <o.13> DBG_GPDMA1_13_STOP       <i> GPDMA1 channel 13 is frozen while CPU is in debug mode
+//   <o.12> DBG_GPDMA1_12_STOP       <i> GPDMA1 channel 12 is frozen while CPU is in debug mode
+//   <o.11> DBG_GPDMA1_11_STOP       <i> GPDMA1 channel 11 is frozen while CPU is in debug mode
+//   <o.10> DBG_GPDMA1_10_STOP       <i> GPDMA1 channel 10 is frozen while CPU is in debug mode
+//   <o.9>  DBG_GPDMA1_9_STOP        <i> GPDMA1 channel 9 is frozen while CPU is in debug mode
+//   <o.8>  DBG_GPDMA1_8_STOP        <i> GPDMA1 channel 8 is frozen while CPU is in debug mode
+//   <o.7>  DBG_GPDMA1_7_STOP        <i> GPDMA1 channel 7 is frozen while CPU is in debug mode
+//   <o.6>  DBG_GPDMA1_6_STOP        <i> GPDMA1 channel 6 is frozen while CPU is in debug mode
+//   <o.5>  DBG_GPDMA1_5_STOP        <i> GPDMA1 channel 5 is frozen while CPU is in debug mode
+//   <o.4>  DBG_GPDMA1_4_STOP        <i> GPDMA1 channel 4 is frozen while CPU is in debug mode
+//   <o.3>  DBG_GPDMA1_3_STOP        <i> GPDMA1 channel 3 is frozen while CPU is in debug mode
+//   <o.2>  DBG_GPDMA1_2_STOP        <i> GPDMA1 channel 2 is frozen while CPU is in debug mode
+//   <o.1>  DBG_GPDMA1_1_STOP        <i> GPDMA1 channel 1 is frozen while CPU is in debug mode
+//   <o.0>  DBG_GPDMA1_0_STOP        <i> GPDMA1 channel 0 is frozen while CPU is in debug mode
+// </h>
+DbgMCU_AHB1_Fz = 0x00000000;
+
+// <h> TPIU Pin Routing
+//   <o0> TRACECLK
+//     <i> ETM Trace Clock
+//       <0x00040002=> Pin PE2
+//   <o1> TRACED0
+//     <i> ETM Trace Data 0
+//       <0x0006000D=> Pin PG13
+//       <0x00040003=> Pin PE3
+//       <0x00020001=> Pin PC1
+//   <o2> TRACED1
+//     <i> ETM Trace Data 1
+//       <0x0006000E=> Pin PG14
+//       <0x00040004=> Pin PE4
+//       <0x00020008=> Pin PC8
+//   <o3> TRACED2
+//     <i> ETM Trace Data 2
+//       <0x00040005=> Pin PE5
+//       <0x00030002=> Pin PD2
+//   <o4> TRACED3
+//     <i> ETM Trace Data 3
+//       <0x0002000C=> Pin PC12
+//       <0x00040006=> Pin PE6
+// </h>
+TraceClk_Pin = 0x00040002;
+TraceD0_Pin  = 0x00040003;
+TraceD1_Pin  = 0x00040004;
+TraceD2_Pin  = 0x00040005;
+TraceD3_Pin  = 0x00040006;
+
+// <<< end of configuration section >>>

--- a/Keil.NUCLEO-H563ZI_BSP.pdsc
+++ b/Keil.NUCLEO-H563ZI_BSP.pdsc
@@ -14,13 +14,17 @@
   </licenseSets>
 
   <releases>
-    <release version="1.0.1-dev">
+    <release version="1.0.2-dev">
       Active development ...
       Blinky project:
       - specify thread names using thread attributes
       - rename thread IDs
       - modify app_main_thread (replace loop forever)
       - add DWARF-5 debug information
+      - add RTE_Components.h files
+      - add Blinky+NUCLEO-H563ZI.dbgconf and Blinky+NUCLEO-H563ZI.dbgconf.base@1.0.0 files for the Blinky example
+      - modified the CI workflows Test-Examples.yml and Test-MDK-Middleware-RefApps.yml
+      - updated settings in vcpkg-configuration.json file to use cmsis-toolbox 2.9.0
     </release>
   </releases>
 

--- a/Keil.NUCLEO-H563ZI_BSP.pdsc
+++ b/Keil.NUCLEO-H563ZI_BSP.pdsc
@@ -23,8 +23,6 @@
       - add DWARF-5 debug information
       - add RTE_Components.h files
       - add Blinky+NUCLEO-H563ZI.dbgconf and Blinky+NUCLEO-H563ZI.dbgconf.base@1.0.0 files for the Blinky example
-      - modified the CI workflows Test-Examples.yml and Test-MDK-Middleware-RefApps.yml
-      - updated settings in vcpkg-configuration.json file to use cmsis-toolbox 2.9.0
     </release>
   </releases>
 


### PR DESCRIPTION
- Reworked CI build workflow for the Blinky example.
- Reworked CI build workflow for testing the Middleware examples. Split the action for preparing the MW-RefApps folder structure into 3 smaller actions to improve readability.
- Add dbgconf files for the Blinky example.
- Updated settings in vcpkg-configuration.json file to use cmsis-toolbox 2.9.0
- Updated pack version and release notes.